### PR TITLE
pass only valid Growl options [fix #4]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ rvm:
   - rbx-2
 matrix:
   allow_failures:
-    - rvm: rbx
+    - rvm: rbx-2
     - rvm: jruby
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ matrix:
   allow_failures:
     - rvm: rbx
     - rvm: jruby
+sudo: false

--- a/lib/notiffany/notifier/growl.rb
+++ b/lib/notiffany/notifier/growl.rb
@@ -74,6 +74,7 @@ module Notiffany
       #
       def _perform_notify(message, opts = {})
         opts = { name: "Notiffany" }.merge(opts)
+        opts.select! { |k, _| ::Growl::Base.switches.include?(k) }
         ::Growl.notify(message, opts)
       end
     end


### PR DESCRIPTION
Broken since Notiffany was extracted from Guard