### PR TITLE
add linux-gnu to supported hosts

### DIFF
--- a/lib/notiffany/notifier/base.rb
+++ b/lib/notiffany/notifier/base.rb
@@ -6,6 +6,7 @@ module Notiffany
       HOSTS = {
         darwin:  "Mac OS X",
         linux:   "Linux",
+        'linux-gnu' =>   "Linux",
         freebsd: "FreeBSD",
         openbsd: "OpenBSD",
         sunos:   "SunOS",

--- a/lib/notiffany/notifier/gntp.rb
+++ b/lib/notiffany/notifier/gntp.rb
@@ -28,7 +28,7 @@ module Notiffany
       }
 
       def _supported_hosts
-        %w(darwin linux freebsd openbsd sunos solaris mswin mingw cygwin)
+        %w(darwin linux linux-gnu freebsd openbsd sunos solaris mswin mingw cygwin)
       end
 
       def _gem_name

--- a/lib/notiffany/notifier/libnotify.rb
+++ b/lib/notiffany/notifier/libnotify.rb
@@ -19,7 +19,7 @@ module Notiffany
       private
 
       def _supported_hosts
-        %w(linux freebsd openbsd sunos solaris)
+        %w(linux linux-gnu freebsd openbsd sunos solaris)
       end
 
       def _check_available(_opts = {})

--- a/lib/notiffany/notifier/notifysend.rb
+++ b/lib/notiffany/notifier/notifysend.rb
@@ -23,7 +23,7 @@ module Notiffany
       private
 
       def _supported_hosts
-        %w(linux freebsd openbsd sunos solaris)
+        %w(linux linux-gnu freebsd openbsd sunos solaris)
       end
 
       def _check_available(_opts = {})


### PR DESCRIPTION
That's what's in RbConfig::CONFIG["host_os"] on my system
( Linux Mint 17, based off of Ubuntu 14.04 )

	modified:   lib/notiffany/notifier/base.rb
	modified:   lib/notiffany/notifier/gntp.rb
	modified:   lib/notiffany/notifier/libnotify.rb
	modified:   lib/notiffany/notifier/notifysend.rb