### PR TITLE
notify-send has no gem to check

### DIFF
--- a/lib/notiffany/notifier/notifysend.rb
+++ b/lib/notiffany/notifier/notifysend.rb
@@ -22,6 +22,11 @@ module Notiffany
 
       private
 
+      # notify-send has no gem, just a binary to shell out
+      def _gem_name
+        nil
+      end
+      
       def _supported_hosts
         %w(linux linux-gnu freebsd openbsd sunos solaris)
       end


### PR DESCRIPTION
The notifysend feature was not working in my environment. `guard -d` was reporting:

    Notiffany: notifysend not available (Please add "gem 'notify_send'" to your Gemfile and run your app with "bundle exec".)

From what I can tell there is no "notify_send" gem to install.

After making this change, `guard -d` reports:

    Command execution: which notify-send
    Notiffany is using NotifySend to send notifications.

... and I get my desktop notifications coming up.

I am new to Ruby and new to this project. Please let me know if I've chosen the wrong mechanism to achieve this result and/or whether just having 'nil' as the method body is poor form.