### PR TITLE
Fill in blank homepage in gemspec.

### DIFF
--- a/notiffany.gemspec
+++ b/notiffany.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["cezary@chronomantic.net"]
   spec.summary       = %q{Notifier library (extracted from Guard project)}
   spec.description   = %q{Single wrapper for most popular notification libraries}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/guard/notiffany"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
- Fix homepage in gemspec

----

Also could you please also add some metadata information of this gem in this page https://rubygems.org/gems/notiffany/edit :pray::

Here are some I know:

| URL                   | VALUE                                      |
| --------------------- | ------------------------------------------ |
| **Source Code URL**   | https://github.com/guard/notiffany               |
| **Documentation URL** | http://www.rubydoc.info/gems/notiffany          |
| **Bug Tracker URL**   | https://github.com/guard/notiffany/issues        |
| **Wiki URL**   | https://github.com/guard/notiffany/wiki        |

Thank you!