### PR TITLE
Fix tmux display_message command arguments build process

### DIFF
--- a/lib/notiffany/notifier/tmux.rb
+++ b/lib/notiffany/notifier/tmux.rb
@@ -67,7 +67,7 @@ module Notiffany
 
         def display_message(message)
           clients.each do |client|
-            args += ["-c", client.strip] if client
+            args = ["-c", client.strip] if client
             # TODO: should properly escape message here
             _run("display", *args, "'#{message}'")
           end

--- a/spec/lib/notiffany/notifier/tmux_spec.rb
+++ b/spec/lib/notiffany/notifier/tmux_spec.rb
@@ -35,6 +35,20 @@ module Notiffany
           expect(sheller).to receive(:run).with("tmux display 'foo'")
           subject.display_message("foo")
         end
+
+        context "when displaying on all clients" do
+          subject { described_class.new(:all) }
+
+          it "displays on every client" do
+            allow(sheller).to receive(:stdout).
+              with("tmux list-clients -F '\#{client_tty}'") do
+              "/dev/ttys001\n"
+            end
+
+            expect(sheller).to receive(:run).with("tmux display -c /dev/ttys001 'foo'")
+            subject.display_message("foo")
+          end
+        end
       end
 
       describe "#message_fg=" do


### PR DESCRIPTION
I got an error like following with the configuration of `display_on_all_clients: true`.

```
14:04:30 - ERROR - Guard::RSpec failed to achieve its <run_on_modifications>, exception was:
> [#] NoMethodError: undefined method `+' for nil:NilClass
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier/tmux.rb:70:in `block in display_message'
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier/tmux.rb:69:in `each'
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier/tmux.rb:69:in `display_message'
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier/tmux.rb:321:in `_display_message'
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier/tmux.rb:246:in `_perform_notify'
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier/base.rb:72:in `notify'
> [#] /somewhere/vendor/bundle/ruby/2.2.0/gems/notiffany-0.0.7/lib/notiffany/notifier.rb:183:in `block in notify'
...
```

`args` hasn't been initialized there and don't have to append options continuously so I fixed from `+=` to `=`.

~~And more, I think `clients` has only `String` elements so removed also `if client`.~~
