### PR TITLE
Fix notifysend check when "which" is unavailable

### DIFF
--- a/lib/notiffany/notifier/notifysend.rb
+++ b/lib/notiffany/notifier/notifysend.rb
@@ -32,7 +32,9 @@ module Notiffany
       end
 
       def _check_available(_opts = {})
-        return true unless Shellany::Sheller.stdout("which notify-send").empty?
+        which = Shellany::Sheller.stdout("which notify-send")
+
+        return true unless which.nil? || which.empty?
 
         fail UnavailableError, "libnotify-bin package is not installed"
       end

--- a/spec/lib/notiffany/notifier/notifysend_spec.rb
+++ b/spec/lib/notiffany/notifier/notifysend_spec.rb
@@ -32,10 +32,23 @@ module Notiffany
         context "host is supported" do
           let(:os) { "linux" }
 
-          it "checks if the binary is available" do
-            expect(sheller).to receive(:stdout).with("which notify-send").
-              and_return("foo\n")
-            subject
+          describe 'check_available' do
+            it "checks if the binary is available" do
+              expect(sheller).to receive(:stdout).with("which notify-send").
+                and_return("foo\n")
+              subject
+            end
+
+            context 'binary check returns nil' do
+              before do
+                allow(sheller).to receive(:stdout).with("which notify-send").
+                  and_return(nil)
+              end
+
+              it 'should raise an UnavailableError' do
+                expect { subject }.to raise_error(Base::UnavailableError)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Recently ran into this problem when building my application into a
docker container with a minimal environment.  The `which` utility
wasn't available to my application, so the return value of Sheller's
`stdout` call was nil, which caused the `empty?` check to blow up.

This adds in a nil check as well.