### PR TITLE
Fix tmux version detection when tmux -V reports "master". Fixes #29

### DIFF
--- a/lib/notiffany/notifier/tmux/client.rb
+++ b/lib/notiffany/notifier/tmux/client.rb
@@ -9,7 +9,8 @@ module Notiffany
 
         class << self
           def version
-            Float(_capture("-V")[/\d+\.\d+/])
+            v = _capture("-V")[/(\d+\.\d+)|master/]
+            v == "master" ? Float::MAX : Float(v)
           end
 
           def _capture(*args)


### PR DESCRIPTION
When you compile recent versions of `tmux` from source, `tmux -V` reports `master`, in which case make `Client#version()` report `Float::MAX`.