### PR TITLE
Fix "uninitialized constant Notiffany::VERSION" test failure

### DIFF
--- a/spec/notiffany_spec.rb
+++ b/spec/notiffany_spec.rb
@@ -1,3 +1,5 @@
+require 'notiffany/version'
+
 RSpec.describe Notiffany do
   it 'has a version number' do
     expect(Notiffany::VERSION).not_to be nil


### PR DESCRIPTION
Running notiffany test suite I found following error: 
~~~
$ rspec spec
..........................................................................................................................................................*..................*.....F

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Notiffany::Notifier#initialize when disabled with environment 
     # Not yet implemented
     # ./spec/lib/notiffany/notifier_spec.rb:107

  2) Notiffany::Notifier.notify with multiple notifiers when not connected when a child process shows a deprecation message
     # No reason given
     Failure/Error:
       expect(logger).to receive(:deprecation).
         with(/Notifier.notify\(\) without a prior Notifier.connect/)
     
       the Logger class does not implement the instance method: deprecation
     # ./spec/lib/notiffany/notifier_spec.rb:343:in `block (6 levels) in <module:Notiffany>'

Failures:

  1) Notiffany has a version number
     Failure/Error: expect(Notiffany::VERSION).not_to be nil
     
     NameError:
       uninitialized constant Notiffany::VERSION
     # ./spec/notiffany_spec.rb:3:in `block (2 levels) in <top (required)>'

Finished in 0.23901 seconds (files took 0.20573 seconds to load)
180 examples, 1 failure, 2 pending

Failed examples:

rspec ./spec/notiffany_spec.rb:2 # Notiffany has a version number
~~~
Attached patch is requiring "notiffany/version" to fix this error. 