### PR TITLE
Fix YARD annotation to match arguments

### DIFF
--- a/lib/notiffany/notifier/emacs.rb
+++ b/lib/notiffany/notifier/emacs.rb
@@ -36,11 +36,7 @@ EOF
 
       # Shows a system notification.
       #
-      # @param [String] type the notification type. Either 'success',
-      #   'pending', 'failed' or 'notify'
-      # @param [String] title the notification title
       # @param [String] message the notification message body
-      # @param [String] image the path to the notification image
       # @param [Hash] opts additional notification library options
       # @option opts [String] success the color to use for success
       #   notifications (default is 'ForestGreen')


### PR DESCRIPTION
  - Avoid  [UnknownParam] @param tag has unknown parameter name: type

<details>

```
lib/notiffany/notifier/emacs.rb:39: [UnknownParam] @param tag has unknown parameter name: type
lib/notiffany/notifier/emacs.rb:41: [UnknownParam] @param tag has unknown parameter name: title
lib/notiffany/notifier/emacs.rb:43: [UnknownParam] @param tag has unknown parameter name: image
```

</details>