### PR TITLE
Fix when tmux is not installed or is not found

### DIFF
--- a/lib/notiffany/notifier/tmux/client.rb
+++ b/lib/notiffany/notifier/tmux/client.rb
@@ -9,7 +9,11 @@ module Notiffany
 
         class << self
           def version
-            Float(_capture("-V")[/\d+\.\d+/])
+            begin
+              Float(_capture("-V")[/\d+\.\d+/])
+            rescue TypeError
+              raise Base::UnavailableError, "Could not find tmux"
+            end
           end
 
           def _capture(*args)

--- a/spec/lib/notiffany/notifier/tmux_spec.rb
+++ b/spec/lib/notiffany/notifier/tmux_spec.rb
@@ -11,6 +11,17 @@ module Notiffany
         stub_const("Shellany::Sheller", sheller)
       end
 
+      describe ".version" do
+        context "when tmux is not installed" do
+          it "fails" do
+            allow(sheller).to receive(:stdout).and_return('')
+            expect do
+              described_class.version
+            end.to raise_error(Base::UnavailableError)
+          end
+        end
+      end
+
       describe "#clients" do
         context "when :all is given" do
           subject { described_class.new(:all) }
@@ -175,6 +186,18 @@ module Notiffany
                 to raise_error(
                   Base::UnavailableError,
                   /way too old \(1.6\)/
+                )
+            end
+          end
+
+          context "without tmux" do
+            it "fails" do
+              allow(Tmux::Client).to receive(:version).
+                and_raise(Base::UnavailableError, "Could not find tmux")
+              expect { subject }.
+                to raise_error(
+                  Base::UnavailableError,
+                  "Could not find tmux"
                 )
             end
           end


### PR DESCRIPTION
This PR should fix error when tmux is not installed.

When tmux is not installed,  notiffany fails like:

```
/.../gems/notiffany-0.1.1/lib/notiffany/notifier/tmux/client.rb:12:in `version': undefined method `[]' for nil:NilClass (NoMethodError)
from /.../gems/notiffany-0.1.1/lib/notiffany/notifier/tmux.rb:69:in `_check_available'
from /.../gems/notiffany-0.1.1/lib/notiffany/notifier/base.rb:59:in `initialize'
```

With this PR, notiffany should not fail and outputs warning like `Notiffany: tmux not available (Could not find tmux).` to logger.

This PR should also fix #29 by coincidence, but warning message is not appropriate.