### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,17 @@ language: ruby
 bundler_args: --without development
 rvm:
   - ruby-head
-  - 2.2.5
-  - 2.3.1
-  - jruby-9.0.5.0
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
+  - jruby-9.1.17.0
 sudo: false
 cache: bundler
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem uninstall -v '>= 2' -ax bundler || true # for jruby
+  - gem install bundler -v '~> 1.7'
+matrix:
+  allow_failures:
+    - rvm: ruby-head # ruby-head bundles bundler 2.1


### PR DESCRIPTION
This PR should update ruby verisions to run specs in Travis CI.

- Adds ruby 2.4, 2.5, and 2.6
- Drops ruby 2.2
- Allow failure in ruby-head because ruby-head bundles bundler 2.1.