### PR TITLE
Fix when tmux is not installed or is not found again.

### DIFF
--- a/lib/notiffany/notifier/tmux/client.rb
+++ b/lib/notiffany/notifier/tmux/client.rb
@@ -11,7 +11,7 @@ module Notiffany
           def version
             begin
               Float(_capture("-V")[/\d+\.\d+/])
-            rescue TypeError
+            rescue NoMethodError, TypeError
               raise Base::UnavailableError, "Could not find tmux"
             end
           end

--- a/spec/lib/notiffany/notifier/tmux_spec.rb
+++ b/spec/lib/notiffany/notifier/tmux_spec.rb
@@ -14,7 +14,16 @@ module Notiffany
       describe ".version" do
         context "when tmux is not installed" do
           it "fails" do
-            allow(sheller).to receive(:stdout).and_return('')
+            allow(sheller).to receive(:stdout).and_return(nil)
+            expect do
+              described_class.version
+            end.to raise_error(Base::UnavailableError)
+          end
+        end
+
+        context "when 'tmux -v' doesn't contain float-like string" do
+          it "fails" do
+            allow(sheller).to receive(:stdout).and_return('master')
             expect do
               described_class.version
             end.to raise_error(Base::UnavailableError)


### PR DESCRIPTION
Assumption in #35 was wrong. When tmux cannot be find, `Shellany::Sheller.stdout('tmux -V')` returns `nil`, not empty string (`""`).