### PR TITLE
Added Support for Linux On Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 bundler_args: --without development
+arch:
+  - amd64
+  - ppc64le
 rvm:
   - ruby-head
   - 2.3.8


### PR DESCRIPTION

Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/notiffany/builds/207359240
Please have a look.

Regards,
ujjwal