### PR TITLE
Fix hash argument matching with rspec-mocks 3.10.3 and Ruby 3+.

### DIFF
--- a/spec/lib/notiffany/notifier/detected_spec.rb
+++ b/spec/lib/notiffany/notifier/detected_spec.rb
@@ -95,7 +95,7 @@ module Notiffany
           context "when not available" do
             before do
               allow(foo_mod).to receive(:new).
-                with(foo: :bar).
+                with({ foo: :bar }).
                 and_raise(Notifier::Base::UnavailableError, "something failed")
               allow(logger).to receive(:warning)
             end

--- a/spec/lib/notiffany/notifier/growl_spec.rb
+++ b/spec/lib/notiffany/notifier/growl_spec.rb
@@ -144,11 +144,13 @@ module Notiffany
         it "passes options only Growl can handle" do
           expect(growl).to receive(:notify).with(
             "Foo",
-            sticky:   true,
-            priority: 2,
-            name:     "Notiffany",
-            title:    "Waiting",
-            image:    "/tmp/wait.png"
+            {
+              sticky:   true,
+              priority: 2,
+              name:     "Notiffany",
+              title:    "Waiting",
+              image:    "/tmp/wait.png"
+            }
           )
 
           subject.notify(

--- a/spec/lib/notiffany/notifier/rb_notifu_spec.rb
+++ b/spec/lib/notiffany/notifier/rb_notifu_spec.rb
@@ -39,16 +39,18 @@ module Notiffany
         context "with options passed at initialization" do
           it "uses these options by default" do
             expect(::Notifu).to receive(:show).with(
-              time:    3,
-              icon:    false,
-              baloon:  false,
-              nosound: false,
-              noquiet: false,
-              xp:      false,
-              title:   "Hello",
-              type:    :info,
-              image:   "/tmp/welcome.png",
-              message: "Welcome to Guard"
+              {
+                time:    3,
+                icon:    false,
+                baloon:  false,
+                nosound: false,
+                noquiet: false,
+                xp:      false,
+                title:   "Hello",
+                type:    :info,
+                image:   "/tmp/welcome.png",
+                message: "Welcome to Guard"
+              }
             )
 
             subject.notify("Welcome to Guard", image: "/tmp/welcome.png")
@@ -79,16 +81,18 @@ module Notiffany
         context "without additional options" do
           it "shows the notification with the default options" do
             expect(::Notifu).to receive(:show).with(
-              time:    3,
-              icon:    false,
-              baloon:  false,
-              nosound: false,
-              noquiet: false,
-              xp:      false,
-              title:   "Welcome",
-              type:    :info,
-              image:   "/tmp/welcome.png",
-              message: "Welcome to Guard"
+              {
+                time:    3,
+                icon:    false,
+                baloon:  false,
+                nosound: false,
+                noquiet: false,
+                xp:      false,
+                title:   "Welcome",
+                type:    :info,
+                image:   "/tmp/welcome.png",
+                message: "Welcome to Guard"
+              }
             )
 
             subject.notify("Welcome to Guard",
@@ -100,16 +104,18 @@ module Notiffany
         context "with additional options" do
           it "can override the default options" do
             expect(::Notifu).to receive(:show).with(
-              time:    5,
-              icon:    true,
-              baloon:  true,
-              nosound: true,
-              noquiet: true,
-              xp:      true,
-              title:   "Waiting",
-              type:    :warn,
-              image:   "/tmp/wait.png",
-              message: "Waiting for something"
+              {
+                time:    5,
+                icon:    true,
+                baloon:  true,
+                nosound: true,
+                noquiet: true,
+                xp:      true,
+                title:   "Waiting",
+                type:    :warn,
+                image:   "/tmp/wait.png",
+                message: "Waiting for something"
+              }
             )
 
             subject.notify("Waiting for something",

--- a/spec/lib/notiffany/notifier/terminal_notifier_spec.rb
+++ b/spec/lib/notiffany/notifier/terminal_notifier_spec.rb
@@ -37,7 +37,7 @@ module Notiffany
 
         it "uses these options by default" do
           expect(TerminalNotifier::Guard).to receive(:execute).
-            with(false, title: "Hello", type: :success, message: "any message")
+            with(false, { title: "Hello", type: :success, message: "any message" })
 
           subject.notify("any message")
         end
@@ -46,9 +46,12 @@ module Notiffany
           expect(::TerminalNotifier::Guard).to receive(:execute).
             with(
               false,
-              title: "Welcome",
-              type: :success,
-              message: "any message")
+              {
+                title: "Welcome",
+                type: :success,
+                message: "any message"
+              }
+            )
 
           subject.notify("any message", title: "Welcome")
         end
@@ -56,20 +59,28 @@ module Notiffany
 
       it "should call the notifier." do
         expect(::TerminalNotifier::Guard).to receive(:execute).
-          with(false,
-               title: "any title",
-               type: :success,
-               message: "any message")
+          with(
+            false,
+            {
+              title: "any title",
+              type: :success,
+              message: "any message"
+            }
+          )
 
         subject.notify("any message", title: "any title")
       end
 
       it "should allow the title to be customized" do
         expect(::TerminalNotifier::Guard).to receive(:execute).
-          with(false,
-               title: "any title",
-               message: "any message",
-               type: :error)
+          with(
+            false,
+            {
+              title: "any title",
+              message: "any message",
+              type: :error
+            }
+          )
 
         subject.notify("any message", type: :error, title: "any title")
       end
@@ -77,10 +88,14 @@ module Notiffany
       context "without a title set" do
         it "should show the app name in the title" do
           expect(::TerminalNotifier::Guard).to receive(:execute).
-            with(false,
-                 title: "FooBar Success",
-                 type: :success,
-                 message: "any message")
+            with(
+              false,
+              {
+                title: "FooBar Success",
+                type: :success,
+                message: "any message"
+              }
+            )
 
           # TODO: why would anyone set the title explicitly to nil? and also
           # expect it to be set to a default value?


### PR DESCRIPTION
Passing hash and keyword values as function parameters
breaks test suite when using rspec-mocks >= v3.10.3.

Relevant issue at rspec-mocks: https://github.com/rspec/rspec-mocks/issues/1460