### PR TITLE
darwin21 (apple m1) is supported

### DIFF
--- a/lib/notiffany/notifier/terminal_notifier.rb
+++ b/lib/notiffany/notifier/terminal_notifier.rb
@@ -17,7 +17,7 @@ module Notiffany
         " on Mac OS X 10.8 and later."
 
       def _supported_hosts
-        %w(darwin)
+        %w(darwin darwin21)
       end
 
       def _gem_name


### PR DESCRIPTION
One tiny change to enable support for `darwin21` which is the Apple M1. Works for me just fine.